### PR TITLE
Implement sandboxing functionality to catch when `extra-inputs` list is incomplete

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           context: examples/python
           tags: python-example/base
-          extra-inputs: examples/python/requirements.txt
+          extra-inputs:
+            examples/python/src/demo.py
+            examples/python/requirements.txt
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/action.yml
+++ b/action.yml
@@ -181,6 +181,22 @@ runs:
         FILES=$(echo -n "${{ inputs.extra-inputs }}" | tr '\n' ' ')
         python3 ${{ github.action_path }}/main.py ${FILES:+--files $FILES}
 
+    # todo: the action does not seem to be hashing these inputs:
+    #   - secret-envs: ${{ inputs.secret-envs }}
+    #   - secret-files: ${{ inputs.secret-files }}
+    - name: Populate a build sandbox directory
+      if: steps.main.outputs.build-required == 'true'
+      id: sandbox
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_CONTEXT: ${{ inputs.context }}
+        INPUT_BUILD-CONTEXTS: ${{ inputs.build-contexts }}
+        INPUT_EXTRA-INPUTS: ${{ inputs.extra-inputs }}
+
+      run: |
+        python3 "${{ github.action_path }}/sandbox.py"
+
     - name: Build image
       uses: docker/build-push-action@v5
       if: steps.main.outputs.build-required == 'true'
@@ -191,12 +207,12 @@ runs:
         annotations: ${{ inputs.annotations }}
         attests: ${{ inputs.attests }}
         build-args: ${{ inputs.build-args }}
-        build-contexts: ${{ inputs.build-contexts }}
+        build-contexts: ${{ steps.sandbox.outputs.build-contexts }}
         builder: ${{ inputs.builder }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         cgroup-parent: ${{ inputs.cgroup-parent }}
-        context: ${{ inputs.context }}
+        context: ${{ steps.sandbox.outputs.context }}
         file: ${{ inputs.file }}
         labels: ${{ inputs.labels }}
         load: ${{ inputs.load }}
@@ -218,3 +234,9 @@ runs:
         target: ${{ inputs.target }}
         ulimit: ${{ inputs.ulimit }}
         github-token: ${{ inputs.github-token }}
+
+    - name: Delete sandbox directory
+      if: steps.main.outputs.build-required == 'true'
+      id: clean
+      shell: bash
+      run: rm -rf "${{ steps.sandbox.outputs.tmpdir }}"

--- a/sandbox.py
+++ b/sandbox.py
@@ -24,7 +24,7 @@ def setup_sandbox(paths: list[pathlib.Path], tmpdir: pathlib.Path):
 
 def main() -> int:
     context = pathlib.Path(get_input("context") or ".")
-    extra_inputs = [pathlib.Path(path) for path in get_input("extra-inputs").split('\n')]
+    extra_inputs = [pathlib.Path(path) for path in get_input("extra-inputs").split(' ')]  # todo: why space and not '\n'
     build_contexts = {}
     for build_context in get_input("build-contexts").split('\n'):
         name, *path = build_context.split('=', maxsplit=1)

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+
+from main import get_input, set_output
+
+GITHUB_ACTIONS = bool(os.environ.get('GITHUB_ACTIONS'))
+
+
+def setup_sandbox(paths: list[pathlib.Path], tmpdir: pathlib.Path):
+    for path in paths:
+        if path.is_dir():
+            shutil.copytree(path, tmpdir / path, symlinks=False, dirs_exist_ok=True)
+        else:
+            (tmpdir / path.parent).mkdir(parents=True, exist_ok=True)
+            shutil.copy(path, tmpdir / path.parent)
+
+
+def main() -> int:
+    context = pathlib.Path(get_input("context") or ".")
+    extra_inputs = [pathlib.Path(path) for path in get_input("extra-inputs").split('\n')]
+    build_contexts = {}
+    for build_context in get_input("build-contexts").split('\n'):
+        name, *path = build_context.split('=', maxsplit=1)
+        if not name or len(path) != 1:
+            continue
+        build_contexts[name] = pathlib.Path(path[0])
+
+    # create sandbox directory
+    tmpdir = pathlib.Path(tempfile.mkdtemp())
+
+    # add Dockerfile to sandbox if location is not specified elsewhere
+    if not get_input("file"):
+        extra_inputs.append(context / "Dockerfile")
+    # add .dockerignore to the sandbox, even if unspecified
+    if (dockerignore := (context / ".dockerignore")).exists():
+        extra_inputs.append(dockerignore)
+
+    setup_sandbox(extra_inputs, tmpdir)
+
+    set_output("tmpdir", str(tmpdir.absolute()))
+    set_output("context", str(tmpdir / context))
+    set_output("build-contexts", '\n'.join(f"{name}={str(tmpdir / path)}" for name, path in build_contexts.values()))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sandbox_test.py
+++ b/sandbox_test.py
@@ -1,0 +1,52 @@
+import glob
+import logging
+import pathlib
+import tempfile
+
+import pytest
+import pyfakefs.fake_filesystem
+
+from sandbox import setup_sandbox
+
+# make it clear pytest is required to run the tests
+_ = pytest
+
+
+class TestSandbox:
+    def test_filesystem_file(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        pathlib.Path("a").write_text("a")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            setup_sandbox([pathlib.Path("a")], pathlib.Path(tmpdir))
+            assert (pathlib.Path(tmpdir) / "a").is_file()
+
+    def test_filesystem_dir_with_file(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        pathlib.Path("a/").mkdir()
+        pathlib.Path("a/b").write_text("b")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            setup_sandbox([pathlib.Path("a")], pathlib.Path(tmpdir))
+            assert (pathlib.Path(tmpdir) / "a").is_dir()
+            assert (pathlib.Path(tmpdir) / "a" / "b").is_file()
+
+    def test_filesystem_dir_with_dir_with_file(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        pathlib.Path("a/b").mkdir(parents=True)
+        pathlib.Path("a/b/c").write_text("c")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            setup_sandbox([pathlib.Path("a")], pathlib.Path(tmpdir))
+            assert (pathlib.Path(tmpdir) / "a").is_dir()
+            assert (pathlib.Path(tmpdir) / "a" / "b").is_dir()
+            assert (pathlib.Path(tmpdir) / "a" / "b" / "c").is_file()
+
+    def test_filesystem_file_in_dir_in_dir(self, fs: pyfakefs.fake_filesystem.FakeFilesystem):
+        pathlib.Path("a/b").mkdir(parents=True)
+        pathlib.Path("a/b/c").write_text("c")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            setup_sandbox([pathlib.Path("a/b/c")], pathlib.Path(tmpdir))
+            for g in glob.glob("**/*", recursive=True):
+                logging.debug("%s", g)
+            assert (pathlib.Path(tmpdir) / "a").is_dir()
+            assert (pathlib.Path(tmpdir) / "a" / "b").is_dir()
+            assert (pathlib.Path(tmpdir) / "a" / "b" / "c").is_file()


### PR DESCRIPTION
## In action

Here's how the sandbox works when 

```
examples/python/src/demo.py
```

is missing in `extra-inputs`:

```
Dockerfile:21
--------------------
  19 |     FROM $RUNTIME_BASE_IMAGE as runtime
  20 |     
  21 | >>> COPY src app
  22 |     
  23 |     CMD /opt/venv/bin/python3 app/demo.py
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref d292b4cc-acf7-406d-b50f-82233a76aea4::q2drzasweqckyacxk0u2fx2ph: "/src": not found
```

https://github.com/jiridanek/lazy-docker-build-push-action/actions/runs/12256503330/job/34191897629#step:3:255

## TODO

* [ ] the `todo: why space and not '\n'` line
* [ ] `compute_hash` does not expect to see directories in `extra-input`, but the sandboxing I have expects that, because listing every file in a directory when entire directory is to be put into the build would be unreasonable
* [ ] the sandbox_test.py needs more work (I torn it out of a prototype of mine, so it is separate from the other tests in the project and has this pytest and pyfakefs dependency)
